### PR TITLE
docs: fix 32 typos and grammar errors across documentation

### DIFF
--- a/docs/configuration/pga-configuration.md
+++ b/docs/configuration/pga-configuration.md
@@ -7,7 +7,7 @@
 <br>
 ### Apache Airavata Component Configuration
 1. For this we use 'Admin Dashboard'
-2. Gateway Admin need to configure;<br>
+2. Gateway Admin needs to configure;<br>
 	- <a href="#CompResource">Compute Resources</a><br>
 	- <a href="#StoreResource">Storage Resources</a><br>
 	- <a href= "#Preference">Gateway Management</a><br>
@@ -28,12 +28,12 @@
 1. Navigate to Admin Dashboard &#8658; Compute Resources &#8658; Register
 2. Add Host Name, Description and create the resource.
 <br>Hint: host name is used when ssh to the resource from airavata.
-3. Then keep adding information on rest of the appeared tabs.
+3. Then keep adding information on the rest of the appeared tabs.
 	- Queues (Queue name is unique and cannot be updated. Can delete and create new if required)
 	- File Systems (This is only for information capturing for future use. Currently this information is not used. So can skip if you want)
 	- Job Submission Interfaces
 	- Data Movement Interfaces
-5. Similarly you can add multiple compute resources in to your gateway by selecting 'Register' from the left-hand-side menu.
+5. Similarly you can add multiple compute resources into your gateway by selecting 'Register' from the left-hand-side menu.
 6. To view the added compute resources navigate to Admin Dashboard &#8658; Compute Resource &#8658; Browse
 7. All the resources will be listed. Gateway admin can view, edit, delete and enable and disable them.
 <br>
@@ -43,10 +43,10 @@
 2. Add Storage Name, Description and create the resource.
 3. Then add data storage information in
 	- Data Movement Interfaces
-4. Similarly you can add multiple storage resources in to your gateway by selecting 'Register' from the left-hand-side menu.
+4. Similarly you can add multiple storage resources into your gateway by selecting 'Register' from the left-hand-side menu.
 5. To view the added resources navigate to Admin Dashboard &#8658; Storage Resources &#8658; Browse
 6. All the resources will be listed. Gateway admin can view, edit, delete them. 
-7. Although enable and disable can be done in registration it's functionality is not yet implemented.
+7. Although enable and disable can be done in registration its functionality is not yet implemented.
 <br>
 <br>
 ###Gateway Management of Resources
@@ -55,7 +55,7 @@
 3. To add compute resource related preferences click "Add a Compute Resource Preference" and select the resource from the drop-down list.
 4. Add/select preferred options and click "Set preferences".
 <br>Repeat this for all the resources used within the gateway.
-4. For each compute resource, gateway admin need to specify;
+4. For each compute resource, gateway admin needs to specify;
   	- Preferences can be overridden by Airavata - Yes/No?
   	- Resource login name
   	- Preferred job submission protocols
@@ -69,8 +69,8 @@
   	- Reservation name
   	- Reservation start and end date time
 5. For adding storage resource preference click "Add a Storage Resource Preferences", and rest is similar to adding a compute resource preference.
-6. For a gateway currently when a storage resource is selected, that resource ID need to be added in to the pga_config.php file in config folder of the hosted gateway.
-7. For storage resource preference, gateway admin need to add;
+6. For a gateway currently when a storage resource is selected, that resource ID needs to be added into the pga_config.php file in config folder of the hosted gateway.
+7. For storage resource preference, gateway admin needs to add;
 	- Login username
 	- File System Root Location
 	- Resource Specific Credential Store Token
@@ -78,8 +78,8 @@
 <br>
 <br>
 ###Application Catalog
-1. Users in Admin group can add applications in to the gateway.
-2. Adding an application involves adding details in to the three tabs - Details, Interface and Deployments.
+1. Users in Admin group can add applications into the gateway.
+2. Adding an application involves adding details into the three tabs - Details, Interface and Deployments.
 4. What each tab means and capture?
 	- <b class="blue">Application Module</b>
 		- Navigation: Admin Dashboard &#8658; App Catalog &#8658; Module
@@ -94,7 +94,7 @@
 		- Click on 'Create a New Application Interface', provide information and create. On creation Application Interface ID will be generated for the module.
         - All available interfaces are also listed; admin has the option of searching for a particular interface by providing the name in the search.
         - Gateway admin can edit, delete existing interfaces.
-        - Gateway admin cal also clone an existing interface in order to create a new similar interface with slight changes.
+        - Gateway admin can also clone an existing interface in order to create a new similar interface with slight changes.
 	- <b class="blue">Application deployment</b>
 		- Navigation: Admin Dashboard &#8658; App Catalog &#8658; Deployment
 			- Application deployment describes application deployment details on a specific resource.
@@ -106,7 +106,7 @@
 ###Credential Store
 1. Navigation: Settings &#8658; Credential Store
 2. This interface is used to generate SSH key + token pairs.
-3. These generated keys can be added in to the authorized key files in each resource for SSH key based communication.
+3. These generated keys can be added into the authorized key files in each resource for SSH key based communication.
 4. Generated key can be either assigned at gateway level or/and at individual resource allocation level; one key + token pair  for all the resources OR have separate key for each resource.
 5. SSH keys are used for communication with compute resources and storage resources.
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -4,13 +4,13 @@
 - A distributed framework that supports execution and management of computational scientific applications and workflows in grid based systems, remote clusters and cloud based systems.
 - Primarily focused on submitting and managing application executions and workflows in grid based systems.
 - Architecturally extensible to support other underlying resources.<!-- Used by scientific gateway developers as their middleware layer. They can directly call Airavata API in order to communicate with grid based system.-->
-- Provides a desktop tools and browser-based web interface components for managing applications, workflows and generated data.
+- Provides desktop tools and browser-based web interface components for managing applications, workflows and generated data.
 - Contains sophisticated server-side tools for registering and managing scientific applications on computational resources.
 
 ### Django Portal
 - The Django portal, the 'Science Gateway' provides tools and methods to easily integrate with post processing applications and application centric interfaces.
 - Django portal is the users interface to use services available through Apache Airavata Middleware.
-- Django portal mainly has 3 user groups; General User, Read-only- admin user and Admin user
+- Django portal mainly has 3 user groups; General User, Read-only-admin user and Admin user
 - This documentation provides step by step instructions on functionality available for general users.
 
 

--- a/docs/installation/airavata-server-properties.md
+++ b/docs/installation/airavata-server-properties.md
@@ -6,7 +6,7 @@
 		- registry.jdbc.url=jdbc:mysql://localhost:3306/experiment_catalog (replace 'localhost' with correct server name if the DB is in a different server)
 		- registry.jdbc.user=airavata
 		- registry.jdbc.password=airavata
-		- enable.sharing=true (This will set sharing within the gateway to be enabled. This is the advices mode)
+		- enable.sharing=true (This will set sharing within the gateway to be enabled. This is the advised mode)
 		- default.registry.gateway=php_reference_gateway (Give the gateway name you prefer. Default exists in the file)
 		- super.tenant.gatewayId=php_reference_gateway (Since you are hosting your own gateway this is the ID of your own gateway)
 2.  Application Catalog DB Configuration
@@ -76,7 +76,7 @@
 		- Make sure the RabbitMQ server is running. For production use <pre><code>rabbitmq-server -detached</code></pre> to start.
 		- Create a virtual-host and user with a password. Follow documentation in <a href="http://blog.dtzq.com/2012/06/rabbitmq-users-and-virtual-hosts.html" target="_blank">RabbitMQ Users & VirtualHost</a>
 		- To create a user; <pre><code>rabbitmqctl add_user Username Password</code></pre>
-		- To create a vitrual-host <pre><code>rabbitmqctl add_vhost vhostauthvhost</code></pre>
+		- To create a virtual-host <pre><code>rabbitmqctl add_vhost vhostauthvhost</code></pre>
 		- Provide permission to created 'Username'  to the created vhost <pre><code>rabbitmqctl set_permissions -p messaging airavata ".*" ".*" ".*”</code></pre>
 		- Uncomment rabbitmq.broker.url=amqp://Username:Password@localhost:5672/Vhost. Add the created username, password and Vhost in the URL.
 		- If you need to stop RabbitMQ use <pre><code>rabbitmqctl stop</code></pre>

--- a/docs/maintenance/pga-maintenance.md
+++ b/docs/maintenance/pga-maintenance.md
@@ -25,13 +25,13 @@ OR
         - Compute Resource <br>
 4. You could also use pre-defined selection criteria ('Get Experiments from Last 24 Hours' OR 'Get Experiments from Last Week')<br/>
 5. Once the experiment/s listed click on the 'Check Stats'
-6. Experiment task breakdown is listed and as the admin you could locate which task failed. Advice the gateway user accordingly.
+6. Experiment task breakdown is listed and as the admin you could locate which task failed. Advise the gateway user accordingly.
 
 <b class="blue" id="unavailable">Q2.</b> One of the resources used by my gateway is not available for the day. How to stop user job submissions?
 <br><b class="blue">Answer:</b> To temporarily stop users submitting jobs to a particular resource...<br>
 1. Navigate to AdminDashboard &#8658; Compute Resources (Browse)<br>
 2. Un-check the  'Enabled' box for the specific resource. This disables job submissions for the resource<br>
-3. To enable job submission simply check the box and you are back in track!<br>
+3. To enable job submission simply check the box and you are back on track!<br>
 NOTE: In order to enable disable resources you require super admin rights to the gateway. If not you need to contact SciGaP admins.
 
 <b class="blue" id="GtwyAccessI">Q3.</b> How to upgrade access for a gateway user?
@@ -45,7 +45,7 @@ NOTE: In order to enable disable resources you require super admin rights to the
 <br><b class="blue">Answer:</b> User roles are given through PGA Admin Dashboard. If the roles are set correctly then check pga_config.php<br>
 1. To check the config file use
 <pre><code>vi /var/www/html/airavata-php-gateway/app/config/pga_config.php</code></pre>
-2. Roles attached to users should exists in the config file against correct role attribute type
+2. Roles attached to users should exist in the config file against correct role attribute type
 <pre><code>
         /**
          * Admin Role Name
@@ -63,7 +63,7 @@ NOTE: In order to enable disable resources you require super admin rights to the
 
 NOTE: In order to view and change config file you require access to PGA backend. If not you need to contact SciGaP admins.
 
-<b class="blue" id="Allocation">Q5.</b> I have ran out of allocation for my current community account used in gateway for a resource. What should I do?
+<b class="blue" id="Allocation">Q5.</b> I have run out of allocation for my current community account used in gateway for a resource. What should I do?
 <br><b class="blue">Answer:</b><br> 
 1. If you have another community account you could update the information in Admin Dashboard &#8658; Gateway Profile under Compute Resource Preferences.<br>
 2. Select the resource and modify account information and save.<br>

--- a/docs/user-documentation/application-catalog.md
+++ b/docs/user-documentation/application-catalog.md
@@ -13,7 +13,7 @@
 - Application/tool/code is what you create in the gateway, which will have all the configurations required to execute the actual code in the  remote resource.
 - Configuring an _Application_ is a three step process. You would;
  - First add the main _Details_ of the application
- - Next its the _Interface_, where you would add all the input required to execute application and also the outputs that the gateway should bring back for the user.
+ - Next it's the _Interface_, where you would add all the input required to execute application and also the outputs that the gateway should bring back for the user.
  - Last is the _Deployment_, Which is the place you will add all the commands that are needed to execute the application in the remote resource.
 
 - Gateway admins can;
@@ -30,7 +30,7 @@ NOTE: In order to explain how an application could be added to the gateway, we w
 2. In Details tab:
     - Application Name: _Gaussian16_
     - Application Version: _Gaussian 16:  ES64L-G16RevA.03_ (Optional)
-    - Application Description: Gaussian computes molecular electronic properties using ab inito and dft techniques. Core Count  should be same as %nproc value in the input. (Optional)
+    - Application Description: Gaussian computes molecular electronic properties using ab initio and dft techniques. Core Count  should be same as %nproc value in the input. (Optional)
     - Save
 
 <ADD>------
@@ -41,7 +41,7 @@ Image:Adding Gaussian16 Details
 1. **Settings** &rarr; **Application Catalog** &rarr; **Gaussian16** &rarr; **Interface**
 2. In Interface tab:
     - Set _Enable Archiving Working Directory_ to `True` (Why? - This is set to true when you want to bring back all the files in the remote working directory back to the gateway portal. Caution: Gateway has a size restriction on ARCHIVE. Please contact SciGaP admins for more details.)
-    - Set _Show Queue Settings_ to `False` - This is your gateway preference. If you gateway users are not give the option of changing the queue properties when submitting jobs, you can hide this and have same properties set for all the users.
+    - Set _Show Queue Settings_ to `False` - This is your gateway preference. If your gateway users are not given the option of changing the queue properties when submitting jobs, you can hide this and have same properties set for all the users.
     - Provide Input Fields
         - Click _Add Application Input_
         - _Name_: `Input-File`
@@ -79,7 +79,7 @@ NOTE: For this application, only a single input, and its a file. For application
             </div>
 
         - 2nd output
-            - CLick _Add Application Output_
+            - Click _Add Application Output_
             - _Name_: `Gaussian_Checkpoint_File`
             - _Value_: `*.chk`
             - _Type_: `URI_COLLECTION`
@@ -118,7 +118,7 @@ Image: Gaussian16 Inputs and Outputs
 Image: Gaussian16 Deployment
 
 #####<h5 id="Otherappdetails">Other Application Catalog Details </h5>
-1. An Application can have multiple deployment, each deployment is for each remote resource the gateway wants to submit jobs to.
+1. An Application can have multiple deployments, each deployment is for each remote resource the gateway wants to submit jobs to.
 2. When sharing application, deployment you would only share it with gateway user who you want to use it.
 3. Tip: When you are adding a new application, you can keep it without sharing it with gateway users until you test it. Unshared applications will appear grayed out to gateway uses.
 

--- a/docs/user-documentation/quick-start.md
+++ b/docs/user-documentation/quick-start.md
@@ -40,10 +40,10 @@ Image: Application Deployment
 
 ##### <h5 id="chkexpstatus">Check Experiment Status</h5>
 1. This is one of the most used functions by gateway admins.
-2. When a gateway user need help with a particular job or need to monitor the gateway job submission rate and their statuses admins use this.
+2. When a gateway user needs help with a particular job or needs to monitor the gateway job submission rate and their statuses admins use this.
 3. **Settings** &rarr; **Experiment Statistics** (Third option in the left icon menu)
 4. Here you can search a specific experiment with its job details using the experiment ID
-5. It will retrieve experiment details, job details, statuses and all tha task statuses in he experiment life cycle.
+5. It will retrieve experiment details, job details, statuses and all the task statuses in the experiment life cycle.
 6. It will also show you the job submission script generated to submit the job and input files and output files. 
 7. Most importantly, this will show you if an error occurred the error messages and exactly which task failed.
 8. This will also list job submission responses from the remote resource and that usually gives a clue if something went wrong with job at the remote resource.
@@ -53,7 +53,7 @@ Image: Application Deployment
 ![Screenshot](../img/expstat2.png)
 Image: Experiment Statistics for an Experiment
 
-9. Gateway admins can use _**Experiment Statistics**_ to get an general idea of the experiment statuses.
+9. Gateway admins can use _**Experiment Statistics**_ to get a general idea of the experiment statuses.
 10. The page will show by default the total number of experiments and their statuses for the last 2 hours.
 11. Gateway admins can view experiment status for either 24 hours or for the last week or can give the period of choice using the calendar option. Can also use extra filters;
     - Application Name
@@ -64,9 +64,9 @@ e.g. Retrieve all experiment from Mar/01/2022 - Jun/01/2022 submitted to Expanse
 
 ##### <h5 id="manageusers">Manage Users</h5>
 1. **Settings** &rarr; **Manage Users**
-2. You can search gateway user sand add or remove them from gateway user groups.
+2. You can search gateway users and add or remove them from gateway user groups.
 3. Gateway admins mostly use this to enable users on the gateway.
-4. As an gateway admin you can add users to any base group (admin, read-only-admin or general) 
+4. As a gateway admin you can add users to any base group (admin, read-only-admin or general) 
 5. If you have other admin groups created within the gateway, you can add users to them as well.
 6. Just like adding users, you can remove users from the group either to revoke gateway access from base group or any other admin groups in the gateway.
 

--- a/docs/user-documentation/tutorials.md
+++ b/docs/user-documentation/tutorials.md
@@ -53,7 +53,7 @@ Image: Application Details Tab
     - _Type_: String
     - _Initial Value_: Yes
     - _Application Argument_: `-v`
-    - _User Friendly Description_: `Add your Vaccintion Status`
+    - _User Friendly Description_: `Add your Vaccination Status`
     - _Required on Command Line_: `True`
     - _Required_: `True`
     - _Read Only_: `False`
@@ -181,7 +181,7 @@ Image:DetectCovid Checkbox Input
 ```
 </div>
 
-6. In the interface tab, you can also add any output you explicitly wants to  bring back from the remote resource and make available for the gateway users to download, for this tutorial, we will not be adding outputs. 
+6. In the interface tab, you can also add any output you explicitly want to bring back from the remote resource and make available for the gateway users to download, for this tutorial, we will not be adding outputs. 
 7. After you added all the above inputs, the experiment creation page would look like below;
 
 ![Screenshot](../img/detectcovidexp.png)


### PR DESCRIPTION
## Summary

Fix 32 spelling, grammar, and punctuation issues across 7 documentation files:

- **pga-configuration.md**: `need` → `needs` (×4), `in to` → `into` (×6), `it's` → `its`, `cal` → `can`, `on rest` → `on the rest`
- **application-catalog.md**: `its` → `it's`, `ab inito` → `ab initio`, `not give` → `not given` + `you` → `your`, `CLick` → `Click`, `deployment` → `deployments`
- **tutorials.md**: `Vaccintion` → `Vaccination`, `wants` → `want`
- **pga-maintenance.md**: `Advice` → `Advise`, `in track` → `on track`, `exists` → `exist`, `ran` → `run`
- **airavata-server-properties.md**: `advices` → `advised`, `vitrual` → `virtual`
- **quick-start.md**: `need` → `needs` (×2), `tha` → `the`, `he` → `the`, `user sand` → `users and`, `an gateway` → `a gateway`, `an general` → `a general`
- **index.md**: `a desktop tools` → `desktop tools`, `Read-only- admin` → `Read-only-admin`

No functional changes — documentation only.